### PR TITLE
Add new test adventure, modify messages

### DIFF
--- a/alan_es/Foundation/mensajes.i
+++ b/alan_es/Foundation/mensajes.i
@@ -203,7 +203,7 @@ WHICH_PRONOUN_FIRST: "$+1"
     --       prompt where the user will be typing the response.
     ----------------------------------------------------------------------
 
-REALLY: "¿Estás seguro (RETURN confirms) ? "
+REALLY: "¿Estás seguro (presiona ENTER para confirmar)? "
 
 QUIT_ACTION: "¿Quiere revertir (undo), recomenzar (restart), restaurar (restore) o salir (quit)? "
     --------------------------------------------------------------

--- a/alan_es/Foundation/meta_sesión.i
+++ b/alan_es/Foundation/meta_sesión.i
@@ -22,7 +22,7 @@ Meta verb q
 End verb.
 
 
-Synonyms grabar, graba, salvar, salva = 'save'.
+Synonyms grabar, graba, salvar, salva, guardar, guarda = 'save'.
 
 Syntax 'save' = 'save'.
 
@@ -45,7 +45,7 @@ Meta verb 'restore'
 End verb.
 
 
-Synonyms comenzar, comienzo, comienza, recomenzar = 'restart'.
+Synonyms comenzar, comienzo, comienza, recomenzar, reiniciar, reinicia = 'restart'.
 
 Syntax 'restart' = 'restart'.
 

--- a/alan_es/tests/meta-messages-test.a3s
+++ b/alan_es/tests/meta-messages-test.a3s
@@ -1,0 +1,148 @@
+﻿look
+> ; =========================================================================
+> ;                                 TICKER
+> ; **************************************************************************
+> ; @TODO: Implement the ticker correctly to check turn skipping; it's
+> ; currently not working, so this section is incomplete.
+> ; **************************************************************************
+> ; =========================================================================
+> ; EMPTY COMMANDS
+> ; =========================================================================
+> ; Empty commands should consume a turn.
+
+
+> ; =========================================================================
+> ; WRONG AND FAIL COMMANDS
+> ; =========================================================================
+> ; Wrong commands and commands that cannot execute should not consume a turn.
+toma tabla
+e
+
+> ; =========================================================================
+> ; CREDITS
+> ; =========================================================================
+creditos
+
+> ; =========================================================================
+> ; SAVING A GAME
+> ; =========================================================================
+guardar
+meta-messages.sav
+
+> ; =========================================================================
+> ;                             SCORE
+> ; =========================================================================
+> ; NOTE: In the test adventure from the STD Library (the one this is based
+> ; on) was a NOTIFY command that could be activated or deactivated. This
+> ; made the game to notify the SCORE to the players whenever they gained a
+> ; point. However, since the Spanish Library doesn't include this feature,
+> ; these tests were excluded.
+> ; ------------------------------------------------------------------------
+> ; We need to test the correct functioning of the SCORE statement. For this
+> ; we are using "drinks": each drink rewards the player with some points.
+score
+x tabla
+x refresco
+bebe refresco
+x tabla
+bebe cafe
+x jugo
+bebe jugo
+score
+bebe agua
+x tabla
+
+> ; =========================================================================
+> ; TEST TRANSCRIPT
+> ; =========================================================================
+> ; @NOTE: "script" does not working. Does this has something to do with the
+> ; Spanish Library syntax or is the "script" function simply not included?
+script
+script on
+
+> ; =========================================================================
+> ; RESTORING A GAME
+> ; =========================================================================
+restore
+meta-messages.sav
+
+> ; The score should be 0.
+score
+> ; All fruits should be present.
+x jugo
+x agua
+x refresco
+x cafe
+
+> ; =========================================================================
+> ; TEST EXAMINING A CLASS
+> ; =========================================================================
+x bebida
+
+bebe agua
+score
+
+> ; =========================================================================
+> ; RESTARTING A GAME
+> ; =========================================================================
+reiniciar
+> ; -------------------------------------------------------------------------
+> ; If somenthing besides pressing ENTER is done.
+> ; -------------------------------------------------------------------------
+look
+> ; Does not restart (good).
+x agua
+> ; This one does restart.
+reiniciar
+
+> ; =========================================================================
+> ; TEST ERROR MESSAGES WHEN RESTORING
+> ; =========================================================================
+> ; -------------------------------------------------------------------------
+> ; RESTORE A NON-EXISTING FILE
+> ; -------------------------------------------------------------------------
+restore
+unknown.sav
+
+> ; -------------------------------------------------------------------------
+> ; RESTORE A FILE WHICH IS NOT A SAVED GAME
+> ; -------------------------------------------------------------------------
+restore
+meta-messages.a3c
+
+> ; -------------------------------------------------------------------------
+> ; RESTORE A FILE SAVED WITH AN OLDER ARUN VERSION
+> ; -------------------------------------------------------------------------
+restore
+prev-version-meta-messages.sav
+
+
+> ; =========================================================================
+> ; QUITTING A GAME
+> ; =========================================================================
+> ; Testing all Quit options.
+> ; -------------------------------------------------------------------------
+> ; QUIT + RESTART
+> ; -------------------------------------------------------------------------
+quit
+restart
+
+> ; -------------------------------------------------------------------------
+> ; QUIT + UNDO
+> ; -------------------------------------------------------------------------
+quit
+undo
+
+> ; -------------------------------------------------------------------------
+> ; QUIT + RESTORE
+> ; -------------------------------------------------------------------------
+quit
+restore
+meta-messages.sav
+
+> ; -------------------------------------------------------------------------
+> ; QUIT + QUIT
+> ; -------------------------------------------------------------------------
+> ; Definitively quitting the game.
+quit
+quit

--- a/alan_es/tests/meta-messages-test.a3t
+++ b/alan_es/tests/meta-messages-test.a3t
@@ -1,0 +1,294 @@
+Estás en la Sala de pruebas. Aquí se verifica que todo vaya bien con los
+juegos de ALAN. Fuiste escogido para ser un sujeto de pruebas debido
+a tus extraordinarias habilidades (y quizás tu atractiva apariencia tuvo
+algo que ver).
+
+Hoy comprobarás que todo marcha bien con ciertos meta-comandos del juego.
+Recuerda que a pesar de haber sido escogido, este trabajo no es
+remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
+
+¡Mucha suerte y gracias por contribuir con ALAN!
+
+-ALAN Enterprises
+
+
+Sala de pruebas
+Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
+de punta y sujetos de prueba extremadamente competentes (como tú). Hay una
+tabla de puntuaciones, un refresco, un café, un jugo de naranja y un vaso
+de agua.
+
+
+> look
+Sala de pruebas
+Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
+de punta y sujetos de prueba extremadamente competentes (como tú). Hay una
+tabla de puntuaciones, un refresco, un café, un jugo de naranja y un vaso
+de agua.
+
+> ; =========================================================================
+> ;                                 TICKER
+> ; **************************************************************************
+> ; @TODO: Implement the ticker correctly to check turn skipping; it's
+> ; currently not working, so this section is incomplete.
+> ; **************************************************************************
+> ; =========================================================================
+> ; EMPTY COMMANDS
+> ; =========================================================================
+> ; Empty commands should consume a turn.
+>
+
+> ; =========================================================================
+> ; WRONG AND FAIL COMMANDS
+> ; =========================================================================
+> ; Wrong commands and commands that cannot execute should not consume a turn.
+> toma tabla
+¡No puedes tomar la tabla de puntuaciones!
+
+> e
+No puedes ir por ahí.
+
+
+> ; =========================================================================
+> ; CREDITS
+> ; =========================================================================
+> creditos
+El autor tiene el copyright de este juego.
+
+Este juego se ha creado utilizando ALAN Adventure Language. ALAN es un
+sistema de autoría de ficción interactiva por Thomas Nilefalk
+email: thomas@alanif.se
+
+Puedes encontrar más información sobre ALAN en la web:
+    https://www.alanif.se
+
+
+> ; =========================================================================
+> ; SAVING A GAME
+> ; =========================================================================
+> guardar
+Nombre de archivo para guardar (meta-messages.sav) : meta-messages.sav
+¡Perfecto!.
+
+
+> ; =========================================================================
+> ;                             SCORE
+> ; =========================================================================
+> ; NOTE: In the test adventure from the STD Library (the one this is based
+> ; on) was a NOTIFY command that could be activated or deactivated. This
+> ; made the game to notify the SCORE to the players whenever they gained a
+> ; point. However, since the Spanish Library doesn't include this feature,
+> ; these tests were excluded.
+> ; ------------------------------------------------------------------------
+> ; We need to test the correct functioning of the SCORE statement. For this
+> ; we are using "drinks": each drink rewards the player with some points.
+> score
+Has logrado 0 puntos de un total de 207.
+
+> x tabla
+La tabla de puntuaciones muestra 0 puntos.
+
+> x refresco
+Un refresco de cola. Probablemente delicioso, pero con mucha azúcar.
+
+> bebe refresco
+Te bebes el refresco.
+
+> x tabla
+La tabla de puntuaciones muestra 1 punto.
+
+> bebe cafe
+Te bebes el café.
+
+> x jugo
+Un refrescante jugo de naranja. ¡La vitamina C es muy beneficiosa!
+
+> bebe jugo
+Te bebes el jugo de naranja.
+
+> score
+Has logrado 7 puntos de un total de 207.
+
+> bebe agua
+Te bebes el vaso de agua.
+
+> x tabla
+La tabla de puntuaciones muestra 207 puntos.
+
+
+> ; =========================================================================
+> ; TEST TRANSCRIPT
+> ; =========================================================================
+> ; @NOTE: "script" does not work. Does this has something to do with the
+> ; Spanish Library syntax or is the "script" function simply not included?
+> script
+La palabra "script" no es relevante.
+
+> script on
+La palabra "script" no es relevante.
+
+> ; =========================================================================
+> ; RESTORING A GAME
+> ; =========================================================================
+> restore
+Nombre del archivo para cargar (meta-messages.sav) : meta-messages.sav
+Hecho.
+
+Sala de pruebas
+Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
+de punta y sujetos de prueba extremadamente competentes (como tú). Hay una
+tabla de puntuaciones, un refresco, un café, un jugo de naranja y un vaso
+de agua.
+
+> ; The score should be 0.
+> score
+Has logrado 0 puntos de un total de 207.
+
+> ; All fruits should be present.
+> x jugo
+Un refrescante jugo de naranja. ¡La vitamina C es muy beneficiosa!
+
+> x agua
+Un vaso de agua increíblemente saludable.
+
+> x refresco
+Un refresco de cola. Probablemente delicioso, pero con mucha azúcar.
+
+> x cafe
+Un poco de café caliente. Te vendría bien para esa cara de sueño...
+
+> ; =========================================================================
+> ; TEST EXAMINING A CLASS
+> ; =========================================================================
+> x bebida
+La palabra "bebida" no es relevante.
+
+
+> bebe agua
+Te bebes el vaso de agua.
+
+> score
+Has logrado 200 puntos de un total de 207.
+
+> ; =========================================================================
+> ; RESTARTING A GAME
+> ; =========================================================================
+> reiniciar
+
+> ; -------------------------------------------------------------------------
+> ; If somenthing besides pressing ENTER is done.
+> ; -------------------------------------------------------------------------
+¿Estás seguro (presiona ENTER para confirmar)? look
+
+> ; Does not restart (good).
+> x agua
+No hay agua aquí.
+
+> ; This one does restart.
+> reiniciar
+¿Estás seguro (presiona ENTER para confirmar)?
+
+Estás en la Sala de pruebas. Aquí se verifica que todo vaya bien con los
+juegos de ALAN. Fuiste escogido para ser un sujeto de pruebas debido a
+tus extraordinarias habilidades (y quizás tu atractiva apariencia tuvo
+algo que ver).
+
+Hoy comprobarás que todo marcha bien con ciertos meta-comandos del juego.
+Recuerda que a pesar de haber sido escogido, este trabajo no es
+remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
+
+¡Mucha suerte y gracias por contribuir con ALAN!
+
+-ALAN Enterprises
+
+
+Sala de pruebas
+Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
+de punta y sujetos de prueba extremadamente competentes (como tú). Hay una
+tabla de puntuaciones, un refresco, un café, un jugo de naranja y un vaso
+de agua.
+
+> ; =========================================================================
+> ; TEST ERROR MESSAGES WHEN RESTORING
+> ; =========================================================================
+> ; -------------------------------------------------------------------------
+> ; RESTORE A NON-EXISTING FILE
+> ; -------------------------------------------------------------------------
+> restore
+Nombre del archivo para cargar (meta-messages.sav) : unknown.sav
+Lo siento, no puedo abrir ese archivo.
+
+> ; -------------------------------------------------------------------------
+> ; RESTORE A FILE WHICH IS NOT A SAVED GAME
+> ; -------------------------------------------------------------------------
+> restore
+Nombre del archivo para cargar (meta-messages.sav) : meta-messages.a3c
+Ese archivo no parece ser una partida guardada.
+
+> ; -------------------------------------------------------------------------
+> ; RESTORE A FILE SAVED WITH AN OLDER ARUN VERSION
+> ; -------------------------------------------------------------------------
+> restore
+Nombre del archivo para cargar (meta-messages.sav) : prev-version-meta-messages.sav
+Lo siento, el archivo fue creado por otra versión de Alan.
+
+
+> ; =========================================================================
+> ; QUITTING A GAME
+> ; =========================================================================
+> ; Testing all Quit options.
+> ; -------------------------------------------------------------------------
+> ; QUIT + RESTART
+> ; -------------------------------------------------------------------------
+> quit
+
+¿Quiere revertir (undo), recomenzar (restart), restaurar (restore) o
+salir (quit)? restart
+
+
+Estás en la Sala de pruebas. Aquí se verifica que todo vaya bien con los
+juegos de ALAN. Fuiste escogido para ser un sujeto de pruebas debido a
+tus extraordinarias habilidades (y quizás tu atractiva apariencia tuvo
+algo que ver).
+
+Hoy comprobarás que todo marcha bien con ciertos meta-comandos del juego.
+Recuerda que a pesar de haber sido escogido, este trabajo no es
+remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
+
+¡Mucha suerte y gracias por contribuir con ALAN!
+
+-ALAN Enterprises
+
+
+Sala de pruebas
+Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
+de punta y sujetos de prueba extremadamente competentes (como tú). Hay una
+tabla de puntuaciones, un refresco, un café, un jugo de naranja y un vaso
+de agua.
+
+> ; -------------------------------------------------------------------------
+> ; QUIT + UNDO
+> ; -------------------------------------------------------------------------
+> quit
+
+¿Quiere revertir (undo), recomenzar (restart), restaurar (restore) o
+salir (quit)? undo
+Acción revertida.
+
+> ; -------------------------------------------------------------------------
+> ; QUIT + RESTORE
+> ; -------------------------------------------------------------------------
+> quit
+
+¿Quiere revertir (undo), recomenzar (restart), restaurar (restore) o
+salir (quit)? restore
+Nombre del archivo para cargar (meta-messages.a3c) : meta-messages.sav
+
+> ; -------------------------------------------------------------------------
+> ; QUIT + QUIT
+> ; -------------------------------------------------------------------------
+> ; Definitively quitting the game.
+> quit
+
+¿Quiere revertir (undo), recomenzar (restart), restaurar (restore) o
+salir (quit)? quit

--- a/alan_es/tests/meta-messages.alan
+++ b/alan_es/tests/meta-messages.alan
@@ -1,0 +1,147 @@
+﻿-- ***********************************************
+--   META MESSAGES TEST by Ricardo Osio (2021)
+-- ***********************************************
+
+-- |================================================================================================|
+-- |This adventure tests different game messages in Spanish. It's mostly based on "meta-verbs" tests|
+-- |from the ALAN STD Library. Some features from the STD Library are not included in the Spanish   |
+-- |Library, so some functionalities are lacking.                                                   |
+-- |================================================================================================|
+
+Import 'Library.i'.
+
+
+-- ==================================================================================================
+--                                    L O C A T I O N S
+-- ==================================================================================================
+
+-- ***************************************************************************************************
+-- Due to the 'DEFINITION_BLOCK' class not being defined in the Spanish Library, "my_game" has been
+-- defined as a Location, and all other locations are located into it. The "cnt" attribute is used for
+-- the "ticker" event.
+-- ***************************************************************************************************
+
+ The my_game IsA location
+  Has cnt 1.
+ End The.
+
+-- ==================================================================================================
+--  Sala de Pruebas
+-- ==================================================================================================
+
+The salaDePrueba IsA location at my_game
+  Name 'Sala de pruebas'
+  Description
+    "Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología de punta y sujetos de
+    prueba extremadamente competentes (como tú)."
+End The.
+
+
+-- ==================================================================================================
+--                                        S C O R E
+-- ==================================================================================================
+-- A scoreboard to test score and some verbs related.
+
+The tablaDePuntos IsA object at salaDePrueba
+  Has artículo "la".
+  Name 'tabla de puntuaciones'
+  Name scoreboard
+  Name tabla
+  Is Not tomable.
+  Is Not empujable.
+
+  Verb examinar
+    Does Only "La tabla de puntuaciones muestra" Say score.
+      If score = 1 Then
+        Say "punto.".
+      Else
+        Say "puntos.".
+      End If.
+  End Verb examinar.
+End The.
+
+
+-- ==================================================================================================
+--                                       D R I N K S
+-- ==================================================================================================
+-- These drinks are used to test the score. Drinking them rewards the player with points.
+
+-- == The "bebida" class ==
+Every bebida IsA object
+  Is bebible.
+End Every.
+
+-- == refresco (a soda) ==
+The refresco IsA bebida at salaDePrueba
+  Name refresco.
+  Has xDesc "Un refresco de cola. Probablemente delicioso, pero con mucha azúcar.".
+
+  Verb beber
+    Does After Score 1.
+  End Verb.
+End The.
+
+-- == café (coffee) ==
+The café IsA bebida at salaDePrueba
+  Name café. Name cafe.
+  Has xDesc "Un poco de café caliente. Te vendría bien para esa cara de sueño...".
+
+  Verb beber
+    Does After Score 1.
+  End Verb.
+End The.
+
+-- == jugo de naranja (orange juice) ==
+The jugo IsA bebida at salaDePrueba
+  Name 'jugo de naranja'. Name jugo.
+  Has xDesc "Un refrescante jugo de naranja. ¡La vitamina C es muy beneficiosa!".
+
+  Verb beber
+    Does After Score 5.
+  End Verb.
+End The.
+
+-- == agua (a glass of water) ==
+The agua IsA bebida at salaDePrueba
+  Has artículo "el".
+  Is femenina.
+  Name agua. Name 'vaso de agua'.
+  Has xDesc "Un vaso de agua increíblemente saludable.".
+
+  Verb beber
+    Does After Score 200.
+  End Verb.
+End The.
+
+
+
+-- ==================================================================================================
+--                                      T I C K E R
+-- ==================================================================================================
+-- This event will let us know when a turn has been consumed.
+-- *************************************************************************************************
+-- @FIX: The event is currently not working. It may have something to do with the absence of a
+-- proper DEFINITION_BLOCK class, which is more complex than just a location in the STD Library.
+-- *************************************************************************************************
+
+Event ticker
+  "$pTICK... (turno Nro" Say my_game:cnt. ")"
+  Increase cnt Of my_game.
+  Schedule ticker At hero After 1.
+End Event.
+
+
+----------------------------------------------------------------------------------------------------
+
+Start at salaDePrueba.
+  "Estás en la Sala de pruebas. Aquí se verifica que todo vaya bien con los juegos de ALAN.
+  Fuiste escogido para ser un sujeto de pruebas debido a tus extraordinarias habilidades (y quizás tu
+  atractiva apariencia tuvo algo que ver).
+
+  $pHoy comprobarás que todo marcha bien con ciertos meta-comandos del juego. Recuerda que a pesar de
+  haber sido escogido, este trabajo no es remunerado en lo absoluto, pero hey, al menos estás siendo
+  útil ¿no?
+
+  $p¡Mucha suerte y gracias por contribuir con ALAN!
+
+  $p-ALAN Enterprises"


### PR DESCRIPTION
## Messages test

Add 'meta-messages' adventure to test game messages in Spanish.

I used the [meta verbs test](https://github.com/AnssiR66/AlanStdLib/blob/dev-2.2.0/tests/misc/meta-verbs.alan) from the STD Library for reference. However, not all functionalities from that library are present in the Spanish one, so some tests were skipped.

I had a problem with the 'ticker' that is supposed to keep count of player's turns. I'm not sure whether this has something to do with the Library or it's because I did something wrong. Either way, it was marked to be solved when possible.

Besides that, all messages seemed to be working fine.

## Translations and synonyms 

Translate the confirmation message when you try to restart. Before it said "RETURN confirms", which was a little bit confusing. Update with a proper translation. 

Also add new synonyms 'guardar' and 'reiniciar' for 'save' and 'restart',
which are more common and sound more natural in Spanish.