### PR TITLE
Translate and fix several messages

### DIFF
--- a/alan_es/Foundation/lanzar.i
+++ b/alan_es/Foundation/lanzar.i
@@ -14,9 +14,7 @@ Add to every object
     Check obj in hero
       else "¡No tienes" say the obj. "!"
     Does
-      -- @CHECK: Doesn't seem right! (lanzaro|lanzara|lanzaros|lanzaras)???
-      --         Maybe: "No puedes lanzarL" --> lanzarLO, lanzarLA ...
-      "No puedes lanzar" say obj:adj_suf.
+      "No puedes lanzarl" say obj:adj_suf.
       "muy lejos," say the obj.
       "acaba" say obj:verb_suf. "en el suelo."
       Locate obj here.

--- a/alan_es/Foundation/mensajes.i
+++ b/alan_es/Foundation/mensajes.i
@@ -32,8 +32,6 @@ SEE_END: "."
 -- These messages are used when listing the contents of containers, which can be
 -- either container objects or actors.
 
--- @TODO: Should these messages check for gender and number? -- ANSWER: It already checks for number. Checking gender isn't needed
-
 CONTAINS: "$+1"
   If parameter1 is plural
     then "contienen"
@@ -152,7 +150,7 @@ CONTAINMENT_LOOP:
 
 CONTAINMENT_LOOP2:
   "Es imposible poner $+1 en $+2 porque $+2 ya está"
-  If parameter1 is plural then "$$n"
+  If parameter2 is plural then "$$n"
   End if. "dentro de $+1."
 
 -- =============================================================================
@@ -161,19 +159,7 @@ CONTAINMENT_LOOP2:
 
 -- =============================================================================
 
--- @FIXME: 'UNKNOWN_WORD' The original message is "I don't know the word '$1'."
---         The current translation "is not relevant" doesn't convey a clear
---         message to the player, it's as if we're dealing with a non important
---         game object (e.g. a scenery), which is misleading since the problem
---         is that the typed word was not understood -- it could be that the
---         player misspelled it by accident. I don't like the original message
---         "I don't know", and I would prefer something like:
---
---               "I didn't understand the word '$1'."
---
---         See: https://github.com/alan-if/alan/issues/33
-
-UNKNOWN_WORD: "La palabra ""$1"" no es relevante."
+UNKNOWN_WORD: "No entendí la palabra '$1'."
 WHAT: "No entiendo bien esa frase. Redactala de nuevo."
 WHAT_WORD: "No entiendo lo que quieres decir con ""$1""."
 MULTIPLE: "No puedes aplicar ese verbo a varios objetos."
@@ -228,11 +214,7 @@ QUIT_ACTION: "¿Quiere revertir (undo), recomenzar (restart), restaurar (restore
 HAVE_SCORED: "Has logrado $1 puntos de un total de $2."
 
 UNDONE: "Acción '$1' revertida."
-NO_UNDO: "No se puede revertir ahora."
-
--- @TODO: The 'NO_UNDO' message in English is "Nothing to undo.",
---        which I think it's clearer regarding the reason why it's
---        not possible to undo the action. Fix it?
+NO_UNDO: "No hay nada que revertir."
 
 --------------------------------------------------------------------------------
 -- Saving Game Session

--- a/alan_es/tests/actors.a3t
+++ b/alan_es/tests/actors.a3t
@@ -94,7 +94,7 @@ Ya llevas puesto el pantalón.
 No llevas nada. Llevas un pantalón.
 
 > RESET
-La palabra "RESET" no es relevante.
+No entendí la palabra 'RESET'.
 
 > ; ------------------------------------------------------------------------------
 > ; VERB UNDRESS
@@ -117,14 +117,14 @@ No llevas nada que puedas quitarte.
 > ; The Foundation Library allows 'wearable' items to be worn not only by the Hero
 > ; but also by any other actor.
 > RESET
-La palabra "RESET" no es relevante.
+No entendí la palabra 'RESET'.
 
 > ; ------------------------------------------------------------------------------
 > ; NPCs Inventory
 > ; ------------------------------------------------------------------------------
 > ; Examining an actor lists worn items in a separate list form carried ones.
 > x vendedor
-La palabra "vendedor" no es relevante.
+No entendí la palabra 'vendedor'.
 
 > x mujer
 Una mujer comprando víveres. Lleva una blusa un poco sucia. La mujer lleva 
@@ -138,17 +138,17 @@ puestos una blusa y unos aretes.
 Tomas la camiseta.
 
 > RESET
-La palabra "RESET" no es relevante.
+No entendí la palabra 'RESET'.
 
 > toma camiseta de vendedor
-La palabra "vendedor" no es relevante.
+No entendí la palabra 'vendedor'.
 
 > ; ------------------------------------------------------------------------------
 > ; Implicitly Taking Items Worn by NPCs
 > ; ------------------------------------------------------------------------------
 > ; The library no longer supports implicit taking in verbs:
 > RESET
-La palabra "RESET" no es relevante.
+No entendí la palabra 'RESET'.
 
 > lleva camiseta
 Te pones la camiseta.

--- a/alan_es/tests/meta-badcode.a3s
+++ b/alan_es/tests/meta-badcode.a3s
@@ -17,7 +17,7 @@ pone llave en bidón
 ; test f.s
 pone llave en caja
 ; test m.p
-pone llave en bidónes
+pone llave en bidones
 ; test f.p
 pone llave en cajas
 ; ----------------------------------------------------------------------------
@@ -36,7 +36,7 @@ ejecuta CONTAINMENT_LOOP con bidón
 ; test f.s
 ejecuta CONTAINMENT_LOOP con caja
 ; test m.p
-ejecuta CONTAINMENT_LOOP con bidónes
+ejecuta CONTAINMENT_LOOP con bidones
 ; test f.p
 ejecuta CONTAINMENT_LOOP con cajas
 ; ----------------------------------------------------------------------------
@@ -48,8 +48,8 @@ ejecuta CONTAINMENT_LOOP2
 ; test m.s <-> f.s
 ejecuta CONTAINMENT_LOOP2 con bidón y caja
 ; test f.s <-> m.p.
-ejecuta CONTAINMENT_LOOP2 con caja y bidónes
+ejecuta CONTAINMENT_LOOP2 con caja y bidones
 ; test m.p <-> f.s.
-ejecuta CONTAINMENT_LOOP2 con bidónes y caja
+ejecuta CONTAINMENT_LOOP2 con bidones y caja
 ; test f.p <-> m.s.
 ejecuta CONTAINMENT_LOOP2 con cajas y bidón

--- a/alan_es/tests/meta-badcode.a3t
+++ b/alan_es/tests/meta-badcode.a3t
@@ -15,10 +15,10 @@ remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; ****************************************************************************
 > ; *                                                                          *
@@ -26,29 +26,30 @@ agua.
 > ; *                                                                          *
 > ; ****************************************************************************
 > norte
-As you enter the quarantine zone the entrance is automatically sealed by
-a thick led panel sliding from above, insulating the external world from
-the dangerous malformed code snippets which are stored in this restricted
-area of the ALAN Laboratories.
+Al entrar en la zona de cuarentena la entrada es sellada automáticamente
+por un grueso panel de led que se desliza desde arriba, aislando el mundo
+exterior de los peligrosos fragmentos de código malformados que se
+almacenan en esta área restringida de los Laboratorios ALAN.
 
 Cámara de cuarentena de código
-This chamber contains various code snippets and test objects. Hay una 
-llave.
+Esta cámara contiene varios fragmentos de código y objetos de prueba. Hay 
+una llave.
 
 > x código
 Los fragmentos de código son: CANT0, CAN_NOT_CONTAIN, CONTAINMENT_LOOP y 
 CONTAINMENT_LOOP2.
 
 > x objetos
-Los objetos de prueba son: unos bidónes, unas cajas, una caja y un bidón.
+Los objetos de prueba son: unos bidones, unas cajas, una caja y un bidón.
 
 > ; ----------------------------------------------------------------------------
 > ; TEST 'CAN_NOT_CONTAIN'
 > ; ----------------------------------------------------------------------------
 > x CAN_NOT_CONTAIN
-To trigger the CAN_NOT_CONTAIN Run-Time MESSAGE try to put the key found
-in this room inside one of the test objects, which are all containers
-with a TAKING restrictive clause.
+Para activar el mensaje de CAN_NOT_CONTAIN intenta poner la llave que se
+encuentra en esta habitación dentro de uno de los objetos de prueba, los
+cuales son contenedores con una cláusula restrictiva de tipo TAKING: solo
+pueden contener otros objetos de prueba.
 
 > ejecuta CAN_NOT_CONTAIN
 Test me with: PONE LLAVE EN CAJA
@@ -65,8 +66,8 @@ El bidón no puede contener la llave.
 La caja no puede contener la llave.
 
 > ; test m.p
-> pone llave en bidónes
-Los bidónes no pueden contener la llave.
+> pone llave en bidones
+Los bidones no pueden contener la llave.
 
 > ; test f.p
 > pone llave en cajas
@@ -76,8 +77,8 @@ Las cajas no pueden contener la llave.
 > ; TEST 'CANT0'
 > ; ----------------------------------------------------------------------------
 > x CANT0
-Executing this code will trigger the CANT0 Run-Time MESSAGE because
-there's no VERB matching the 'ejecutar' SYNTAX for this object.
+Ejecutar este código activará el mensaje de CANT0 porque no hay un verbo
+que coincida con la SYNTAX 'ejecutar' para este objeto.
 
 > ejecuta CANT0
 No se puede.
@@ -86,8 +87,8 @@ No se puede.
 > ; TEST 'CONTAINMENT_LOOP'
 > ; ----------------------------------------------------------------------------
 > x CONTAINMENT_LOOP
-Executing this code will trigger the CONTAINMENT_LOOP Run-Time MESSAGE by
-attempting to insert an object into itself.
+Ejecutar este código activará el mensaje de CONTAINMENT_LOOP, al intentar
+insertar un objeto dentro de sí mismo.
 
 > ejecuta CONTAINMENT_LOOP
 Poner a el contenedor designado en sí mismo es imposible.
@@ -102,8 +103,8 @@ Poner a el bidón en sí mismo es imposible.
 Poner a la caja en sí misma es imposible.
 
 > ; test m.p
-> ejecuta CONTAINMENT_LOOP con bidónes
-Poner a los bidónes en sí mismos es imposible.
+> ejecuta CONTAINMENT_LOOP con bidones
+Poner a los bidones en sí mismos es imposible.
 
 > ; test f.p
 > ejecuta CONTAINMENT_LOOP con cajas
@@ -113,9 +114,9 @@ Poner a las cajas en sí mismas es imposible.
 > ; TEST 'CONTAINMENT_LOOP2'
 > ; ----------------------------------------------------------------------------
 > x CONTAINMENT_LOOP2
-Executing this code will trigger the CONTAINMENT_LOOP2 Run-Time MESSAGE
-by attempting to insert an object into another object while the latter is
-inside the former.
+Ejecutar este código activará el mensaje de CONTAINMENT_LOOP2, al
+intentar insertar un objeto dentro de otro objeto mientras el primero
+está dentro del segundo.
 
 > ejecuta CONTAINMENT_LOOP2
 Es imposible poner el contenedor designado en el contenedor de destino
@@ -128,19 +129,19 @@ Es imposible poner el bidón en la caja porque la caja ya está dentro de el
 bidón.
 
 > ; test f.s <-> m.p.
-> ejecuta CONTAINMENT_LOOP2 con caja y bidónes
-Es imposible poner la caja en los bidónes porque los bidónes ya está 
+> ejecuta CONTAINMENT_LOOP2 con caja y bidones
+Es imposible poner la caja en los bidones porque los bidones ya están 
 dentro de la caja.
 
 > ; test m.p <-> f.s.
-> ejecuta CONTAINMENT_LOOP2 con bidónes y caja
-Es imposible poner los bidónes en la caja porque la caja ya están dentro
-de los bidónes.
+> ejecuta CONTAINMENT_LOOP2 con bidones y caja
+Es imposible poner los bidones en la caja porque la caja ya está dentro de 
+los bidones.
 
 > ; test f.p <-> m.s.
 > ejecuta CONTAINMENT_LOOP2 con cajas y bidón
-Es imposible poner las cajas en el bidón porque el bidón ya están dentro
-de las cajas.
+Es imposible poner las cajas en el bidón porque el bidón ya está dentro de 
+las cajas.
 
 > 
 

--- a/alan_es/tests/meta-input-errors.a3t
+++ b/alan_es/tests/meta-input-errors.a3t
@@ -15,10 +15,10 @@ remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; ****************************************************************************
 > ; *                                                                          *
@@ -31,8 +31,8 @@ agua.
 > ; ----------------------------------------------------------------------------
 > ; Enable ticker machine to check which input types don't consume a turn:
 > presiona el boton
-As you press the button you ear a humming sound coming from the wall, as
-if a hidden machine came to life. 
+Al presionar el botón escuchas un zumbido que viene de la pared, como si
+una máquina oculta acabase de volver a la vida. 
 
 TICK... (turno Nro 1 )
 
@@ -45,7 +45,7 @@ TICK... (turno Nro 1 )
 > ; ----------------------------------------------------------------------------
 > ; Examine a non-existing object:
 > x Xyzzy
-La palabra "Xyzzy" no es relevante.
+No entendí la palabra 'Xyzzy'.
 
 > ; ****************************************************************************
 > ; ********************|  P E N D I N G   M E S S A G E S  |*******************

--- a/alan_es/tests/meta-session.a3t
+++ b/alan_es/tests/meta-session.a3t
@@ -15,10 +15,10 @@ remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; ****************************************************************************
 > ; *                                                                          *
@@ -35,8 +35,8 @@ agua.
 > ; ----------------------------------------------------------------------------
 > ; Enable ticker machine to check that session meta verbs don't consume a turn:
 > presiona el boton
-As you press the button you ear a humming sound coming from the wall, as
-if a hidden machine came to life. 
+Al presionar el botón escuchas un zumbido que viene de la pared, como si
+una máquina oculta acabase de volver a la vida. 
 
 TICK... (turno Nro 1 )
 
@@ -58,7 +58,7 @@ Acción 'presiona el boton' revertida.
 > ; ----------------------------------------------------------------------------
 > ; Nothing else to undo:
 > undo
-No se puede revertir ahora.
+No hay nada que revertir.
 
 > ; ============================================================================
 > ; SAVING THE GAME || META VERB: 'save'
@@ -112,10 +112,10 @@ Hecho.
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; now the coffee should be back:
 > examina cafe
@@ -187,10 +187,10 @@ remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; now the coffee should be back:
 > examina cafe
@@ -237,10 +237,10 @@ remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; ----------------------------------------------------------------------------
 > ; QUIT + UNDO => TEST 'QUIT_ACTION' + 'UNDONE'

--- a/alan_es/tests/meta-test.a3t
+++ b/alan_es/tests/meta-test.a3t
@@ -15,25 +15,25 @@ remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > look
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > x boton
-It's a really big and menacing red button. Above the button there's a
-sign.
+Es un botón rojo, grande y amenazador. Por encima del botón hay un cartel.
 
 > x cartel
-The sign reads "Press button to toggle the ticker machine on/off".
+El cartel dice "Presione el botón para encender/apagar la máquina de
+tics".
 
 > ; =========================================================================
 > ;                                 TICKER
@@ -41,8 +41,8 @@ The sign reads "Press button to toggle the ticker machine on/off".
 > ; The ticker Event will help us check if META VERBs are behaving as
 > ; expected: if the counter ticks, a turn has been consumed.
 > presiona el boton
-As you press the button you ear a humming sound coming from the wall, as
-if a hidden machine came to life. 
+Al presionar el botón escuchas un zumbido que viene de la pared, como si
+una máquina oculta acabase de volver a la vida. 
 
 TICK... (turno Nro 1 )
 
@@ -156,10 +156,10 @@ TICK... (turno Nro 12 )
 > ; @NOTE: "script" does not working. Does this has something to do with the
 > ; Spanish Library syntax or is the "script" function simply not included?
 > script
-La palabra "script" no es relevante.
+No entendí la palabra 'script'.
 
 > script on
-La palabra "script" no es relevante.
+No entendí la palabra 'script'.
 
 > ; =========================================================================
 > ; RESTORING A GAME
@@ -170,10 +170,10 @@ Hecho.
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; The score should be 0.
 > score
@@ -204,7 +204,7 @@ TICK... (turno Nro 7 )
 > ; TEST EXAMINING A CLASS
 > ; =========================================================================
 > x bebida
-La palabra "bebida" no es relevante.
+No entendí la palabra 'bebida'.
 
 > bebe agua
 Te bebes el agua. 
@@ -237,10 +237,10 @@ remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; -------------------------------------------------------------------------
 > ; If somenthing besides pressing ENTER is done.
@@ -248,10 +248,10 @@ agua.
 > look
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; Does not restart (good).
 > x agua
@@ -278,10 +278,10 @@ remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; =========================================================================
 > ; TEST ERROR MESSAGES WHEN RESTORING
@@ -336,10 +336,10 @@ remunerado en lo absoluto, pero hey, al menos estás siendo útil ¿no?
 
 Sala de pruebas
 Aquí se prueban diversos aspectos del lenguaje ALAN, gracias a tecnología
-de punta y sujetos de prueba extremadamente competentes (como tú). To the
-north lies the quarantine zone. A red button is bolted in the wall. Hay 
-una tabla de puntuaciones, un refresco, un café, un jugo de naranja y una 
-agua.
+de punta y sujetos de prueba extremadamente competentes (como tú). Al
+norte se encuentra la zona de cuarentena. Un botón rojo está atornillado
+a la pared. Hay una tabla de puntuaciones, un refresco, un café, un jugo
+de naranja y una agua.
 
 > ; -------------------------------------------------------------------------
 > ; QUIT + UNDO

--- a/alan_es/tests/meta.alan
+++ b/alan_es/tests/meta.alan
@@ -51,7 +51,7 @@ The salaDePrueba IsA location
     "Aquí se prueban diversos aspectos del lenguaje ALAN,
      gracias a tecnología de punta y sujetos de prueba
      extremadamente competentes (como tú).
-     To the north lies the quarantine zone." -- @TRANSLATE!
+     Al norte se encuentra la zona de cuarentena."
   Exit norte to bugsRoom.
 End The.
 
@@ -142,7 +142,7 @@ End The.
 
 -- We need a ticker to track that META VERBs are not consuming a turn.
 
--- So we implement a "tricker machine" that can be activated and stopped by
+-- So we implement a "ticker machine" that can be activated and stopped by
 -- pressing a red button, and will start ticking in the background at every
 -- turn, letting us know when a turn was consumed (EVENTs are only executed
 -- during consumed game turns, not when executing META VERBS).
@@ -155,7 +155,6 @@ End The.
 -- V E R B  " P R E S S "
 --------------------------------------------------------------------------------
 
--- @CHECK: @Rich15 please confirm if this is correct (if yes, delete this line):
 
 -- We need a dedicated verb for pressing the button, since the "empujar" verb
 -- for "pushing" things is not used for pressing buttons in Spanish
@@ -165,20 +164,20 @@ Add to every thing
   Is not presionable. -- i.e. not pressable.
 End add to thing.
 
-Synonyms -- @CHECK: @Rich15 please look is these syntaxes are OK!
-  presiona, presione, pulsa,  pulse, pulsar =  presionar.
+Synonyms
+  presiona, presione, pulsa,  pulse, pulsar, aprieta, apretar =  presionar.
 
 Syntax
   presionar =  presionar (obj)
     Where obj IsA object
-      else "You can only press objects!" -- @TRANSLATE!
+      else "¡Solo puedes presionar objetos!"
 
 Add to every object
   Verb presionar
     Check obj is empujable
       else "No puedes presionar $+1."
     Does
-      "You press $+1, but nothing happens." -- @TRANSLATE!
+      "Presionas $+1, pero nada sucede."
   End verb.
 End add to.
 
@@ -193,22 +192,22 @@ The botón IsA object at salaDePrueba
   Is not tomable.
   Is not active. -- i.e. the ticker machine state.
   Has cnt 0. -- The ticks counter.
-  Description "A red button is bolted in the wall." -- @TRANSLATE!
-  Has xDesc "It's a really big and menacing red button.
-             Above the button there's a sign.". -- @TRANSLATE!
+  Description "Un botón rojo está atornillado a la pared."
+  Has xDesc "Es un botón rojo, grande y amenazador.
+             Por encima del botón hay un cartel.".
 
   Verb presionar
     Does only
-      "As you press the button" -- @TRANSLATE!
+      "Al presionar el botón"
       If this is not active
         then
-          "you ear a humming sound coming from the wall,
-           as if a hidden machine came to life." -- @TRANSLATE!
+          "escuchas un zumbido que viene de la pared,
+           como si una máquina oculta acabase de volver a la vida."
           Schedule ticker at hero after 0.
           Set this:cnt to 0. -- reset counter.
           Make this active.
-        else -- @TRANSLATE:
-          "the ticker machine stops and the humming from the walls ceases."
+        else
+          "la máquina de tics para y el zumbido de la pared se detiene."
           Cancel ticker.
           Make this not active.
       End if.
@@ -227,8 +226,8 @@ The cartel IsA object at salaDePrueba
   Is not tomable.
   Is leible. -- @TODO: Implement reading (need to check if EN lib uses xDesc)
   Description "" -- Don't mention it in room descriptions!
-  Has xDesc "The sign reads ""Press button to toggle the
-             ticker machine on/off"".". -- @TRANSLATE!
+  Has xDesc "El cartel dice ""Presione el botón para encender/apagar
+             la máquina de tics"".".
 End The.
 
 --------------------------------------------------------------------------------
@@ -263,17 +262,17 @@ End Event.
 The bugsRoom IsA location
   Name 'Cámara de cuarentena de código'
   Description
-    "This chamber contains various code snippets and test objects." -- @TRANSLATE!
+    "Esta cámara contiene varios fragmentos de código y objetos de prueba."
   Entered
-    "As you enter the quarantine zone the entrance is automatically
-     sealed by a thick led panel sliding from above, insulating the
-     external world from the dangerous malformed code snippets which
-     are stored in this restricted area of the ALAN Laboratories." -- @TRANSLATE!
+    "Al entrar en la zona de cuarentena la entrada es sellada automáticamente
+    por un grueso panel de led que se desliza desde arriba, aislando el mundo
+    exterior de los peligrosos fragmentos de código malformados que se
+    almacenan en esta área restringida de los Laboratorios ALAN."
   Exit sur to salaDePrueba
     Does
-      "As you approach the exit, the room sensors activate the X-rays
-       shower to decontaminate you from any residue of buggy code,
-       before lifting the led barrier and letting you through." -- @TRANSLATE!
+      "Al acercarte a la salida, los sensores de la habitación activan la
+      ducha de rayos X para descontaminarte de cualquier residuo de código
+      defectuoso, antes de abrir la barrera de led y dejarte salir."
     End exit.
 End The.
 
@@ -303,7 +302,7 @@ The snippets IsA escenario at bugsRoom.
   Name codigo. Name fragmentos.
   Has artículo "los".
   Container
-    Header "Los fragmentos de código son:" -- @TRANSLATE! (check translation)
+    Header "Los fragmentos de código son:"
   Description ""
   Verb examinar
     Does only list this.
@@ -320,23 +319,23 @@ Synonyms ejecuta, ejecute = ejecutar.
 
 Syntax ejecutar = ejecutar (código)
   Where código IsA code_obj
-    Else "You can only execute code snippets!" -- @TRANSLATE!
+    Else "¡Solo puedes ejecutar fragmentos de código!"
 
 -- Alternative test verbs accepting parameters to test GNA:
 
 Syntax ejecutar_con = ejecutar (código) con (obj)
   Where código IsA code_obj
-    Else "You can only execute code snippets!" -- @TRANSLATE!
+    Else "¡Solo puedes ejecutar fragmentos de código!"
   And obj IsA test_obj
-    Else "You can execute code with designated test objects!" -- @TRANSLATE!
+    Else "¡Solo puedes ejecutar código con objetos de prueba designados!"
 
 Syntax ejecutar_con2 = ejecutar (código) con (obj1) y (obj2)
   Where código IsA code_obj
-    Else "You can only execute code snippets!" -- @TRANSLATE!
+    Else "¡Solo puedes ejecutar fragmentos de código!"
   And obj1 IsA test_obj
-    Else "You can execute code with designated test objects!" -- @TRANSLATE!
+    Else "¡Solo puedes ejecutar código con objetos de prueba designados!"
   And obj2 IsA test_obj
-    Else "You can execute code with designated test objects!" -- @TRANSLATE!
+    Else "¡Solo puedes ejecutar código con objetos de prueba designados!"
 
 --==============================================================================
 --                           C O D E   O B J E C T S
@@ -374,9 +373,9 @@ Syntax ejecutar_con2 = ejecutar (código) con (obj1) y (obj2)
 
 The CONTAINMENT_LOOP2 IsA code_obj in snippets.
   Has xDesc
-    "Executing this code will trigger the CONTAINMENT_LOOP2
-     Run-Time MESSAGE by attempting to insert an object into
-     another object while the latter is inside the former.". -- @TRANSLATE!
+    "Ejecutar este código activará el mensaje de CONTAINMENT_LOOP2, al intentar
+    insertar un objeto dentro de otro objeto mientras el primero está dentro
+    del segundo.".
 
   Verb ejecutar
     Does
@@ -408,9 +407,8 @@ End the CONTAINMENT_LOOP2.
 
 The CONTAINMENT_LOOP IsA code_obj in snippets.
   Has xDesc
-    "Executing this code will trigger the CONTAINMENT_LOOP
-     Run-Time MESSAGE by attempting to insert an object
-     into itself.". -- @TRANSLATE!
+    "Ejecutar este código activará el mensaje de CONTAINMENT_LOOP, al intentar
+    insertar un objeto dentro de sí mismo.".
 
   Verb ejecutar
     Does
@@ -434,9 +432,8 @@ End the CONTAINMENT_LOOP.
 
 The CANT0 IsA code_obj in snippets.
   Has xDesc
-    "Executing this code will trigger the CANT0 Run-Time MESSAGE
-     because there's no VERB matching the 'ejecutar' SYNTAX for
-     this object.". -- @TRANSLATE!
+    "Ejecutar este código activará el mensaje de CANT0 porque no hay un verbo
+    que coincida con la SYNTAX 'ejecutar' para este objeto.".
 End the.
 
 --------------------------------------------------------------------------------
@@ -448,9 +445,11 @@ End the.
 
 The CAN_NOT_CONTAIN IsA code_obj in snippets.
   Has xDesc
-    "To trigger the CAN_NOT_CONTAIN Run-Time MESSAGE try to
-     put the key found in this room inside one of the test objects,
-     which are all containers with a TAKING restrictive clause.". -- @TRANSLATE! End the.
+    "Para activar el mensaje de CAN_NOT_CONTAIN intenta poner la llave que se
+    encuentra en esta habitación dentro de uno de los objetos de prueba, los
+    cuales son contenedores con una cláusula restrictiva de tipo TAKING: solo
+    pueden contener otros objetos de prueba.".
+
   Verb ejecutar
     Does "Test me with: PONE LLAVE EN CAJA"
   End verb.
@@ -475,7 +474,7 @@ The test_objects IsA escenario at bugsRoom.
   Name objetos.
   Has artículo "los".
   Container
-    Header "Los objetos de prueba son:" -- @TRANSLATE! (check translation)
+    Header "Los objetos de prueba son:"
   Description ""
   Verb examinar
     Does only list this.
@@ -493,8 +492,8 @@ The caja IsA test_obj in test_objects.    --> f.s. (box)
   Has artículo "la".
 End the.
 
-The bidónes IsA test_obj in test_objects. --> m.p. (drums)
-  Name bidónes. Name bidones.
+The bidones IsA test_obj in test_objects. --> m.p. (drums)
+  Name bidones.
   Has artículo "los".
 End the.
 


### PR DESCRIPTION
# Translations and updates

## `meta.alan`

Translate all English messages in the 'meta.alan' source adventure and add some more synonyms for the 'presionar' verb.

Also delete the accent mark in 'bidónes' since is incorrect: the correct form is 'bidones' (without accent mark).  Update solutions files based on this.

## `mensajes.i`

Fix an issue with the CONTAINMENT_LOOP2 Run-Time message, which wasn't handling the number of 'estar' verb properly.  The code was using the number of the first parameter instead of the second one.

Improve translation of 'NO_UNDO' and 'UNKNOWN_WORD' messages because the old ones had an unclear meaning in Spanish and didn't convey the reason why the message appeared.

## `lanzar.i`

Fix the GNA in 'lanzar' VERB. As @tajmone noted, "[lanzaro|lanzara|lanzaros|lanzaras]" are not right. Now it shows the proper "No puedes lanzarl$$ muy lejos" message.

# The UNDO command

*From #47*:
> I was wondering whether we should add Spanish SYNONYMS for UNDO, or whether this command is so universal in IF that it doesn't deserve a translation. @Rich15, what do you think?

UNDO is a pretty common command.  However, since the translation of the 'NO_UNDO' message includes "revertir", it could be useful to add it and its imperative form (I.e: "revierte") as a synonym for players who prefer commands in Spanish.